### PR TITLE
Pass CHR RAM pointer to PPU

### DIFF
--- a/src/nofrendo/nes.c
+++ b/src/nofrendo/nes.c
@@ -572,7 +572,7 @@ void nes_destroy(nes_t **machine)
          free((*machine)->cpu);
 
       if ((*machine)->rominfo)
-         rom_freeinfo((*machine)->rominfo);
+         rom_freeinfo((*machine)->rominfo, (*machine)->ppu);
 
       memset(*machine, 0, sizeof(nes_t));
       *machine = NULL;
@@ -585,7 +585,7 @@ int nes_insertcart(const char *filename, nes_t *machine)
    nes_t *nes_ptr = machine ? machine : &nes;
 
    if (NULL != nes_ptr->rominfo)
-      rom_freeinfo(nes_ptr->rominfo);
+      rom_freeinfo(nes_ptr->rominfo, nes_ptr->ppu);
 
    if (NULL == (nes_ptr->rominfo = rom_load(filename)))
       return NESERR_BAD_FILE;

--- a/src/nofrendo/nes_mmc.c
+++ b/src/nofrendo/nes_mmc.c
@@ -176,6 +176,15 @@ static void mmc_setpages(void)
 {
    log_printf("setting up mapper %d\n", mmc.intf->number);
 
+   /* Provide CHR-RAM pointer to the PPU */
+   if (mmc.cart->vram) {
+      ppu_set_chrram(mmc.cart->vram, VRAM_8K * mmc.cart->vram_banks);
+   } else {
+      ppu_set_chrram(NULL, 0);
+   }
+
+   ppu_set_four_screen_mode((mmc.cart->flags & ROM_FLAG_FOURSCREEN) != 0);
+
    /* Switch ROM into CPU space, set VROM/VRAM (done for ALL ROMs) */
    mmc_bankrom(16, 0x8000, 0);
    mmc_bankrom(16, 0xC000, MMC_LASTBANK);

--- a/src/nofrendo/nes_rom.c
+++ b/src/nofrendo/nes_rom.c
@@ -479,12 +479,12 @@ rominfo_t *rom_load(const char *filename)
    return rominfo;
 
 _fail:
-   rom_free(&rominfo);
+   rom_free(&rominfo, NULL);
    return NULL;
 }
 
 /* Free a ROM */
-void rom_free(rominfo_t **rominfo)
+void rom_free(rominfo_t **rominfo, ppu_t *ppu)
 {
    if (NULL == *rominfo)
    {
@@ -493,10 +493,9 @@ void rom_free(rominfo_t **rominfo)
    }
 
    /* Restore palette if we loaded in a VS jobber */
-   if ((*rominfo)->flags & ROM_FLAG_VERSUS)
+   if (ppu && ((*rominfo)->flags & ROM_FLAG_VERSUS))
    {
-      /* TODO: bad idea calling nes_getcontextptr... */
-      ppu_setdefaultpal(nes_getcontextptr()->ppu);
+      ppu_setdefaultpal(ppu);
       log_printf("Default NES palette restored\n");
    }
 
@@ -516,11 +515,11 @@ void rom_free(rominfo_t **rominfo)
    gui_sendmsg(GUI_GREEN, "ROM freed");
 }
 
-void rom_freeinfo(rominfo_t *rominfo)
+void rom_freeinfo(rominfo_t *rominfo, ppu_t *ppu)
 {
    if (rominfo) {
       rominfo_t *temp = rominfo;
-      rom_free(&temp);
+      rom_free(&temp, ppu);
    }
 }
 

--- a/src/nofrendo/nes_rom.h
+++ b/src/nofrendo/nes_rom.h
@@ -28,6 +28,7 @@
 
 #include "unistd.h"
 #include "osd.h"
+#include "new_ppu.h"
 
 typedef enum
 {
@@ -63,8 +64,8 @@ typedef struct rominfo_s
 
 extern int rom_checkmagic(const char *filename);
 extern rominfo_t *rom_load(const char *filename);
-extern void rom_free(rominfo_t **rominfo);
-extern void rom_freeinfo(rominfo_t *rominfo);
+extern void rom_free(rominfo_t **rominfo, ppu_t *ppu);
+extern void rom_freeinfo(rominfo_t *rominfo, ppu_t *ppu);
 extern char *rom_getinfo(rominfo_t *rominfo);
 
 

--- a/src/nofrendo/new_ppu.h
+++ b/src/nofrendo/new_ppu.h
@@ -11,6 +11,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "bitmap.h"
 #include "noftypes.h"
@@ -83,6 +84,7 @@ typedef struct ppu_s ppu_t;
 void ppu_set_mapper_hook(void (*fn)(uint16_t addr));
 void ppu_setlatchfunc(ppulatchfunc_t fn);      /* MMC-2 / MMC-4 latch */
 void ppu_setvromswitch(ppuvromswitch_t fn);    /* VS-System CHR bank  */
+void ppu_set_chrram(uint8_t *ptr, size_t size);/* Cartridge CHR RAM   */
 
 /* ---- Core lifecycle ----------------------------------------------------- */
 void ppu_reset(int hard);   /* hard ≠ 0 → power-on state */


### PR DESCRIPTION
## Summary
- expose `ppu_set_chrram` and cache CHR RAM for direct access
- feed cartridge VRAM to PPU during mapper setup and handle four-screen mode
- remove global context calls in ROM cleanup and related code

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `gcc -Isrc/nofrendo -c src/nofrendo/nes_ppu.c -o /tmp/nes_ppu.o`

------
https://chatgpt.com/codex/tasks/task_e_6899fabacc4083239d339cc864d005ef