### PR TITLE
Support 1KB CHR-RAM paging for fine-grained bankswitching

### DIFF
--- a/src/nofrendo/nesstate.c
+++ b/src/nofrendo/nesstate.c
@@ -319,18 +319,8 @@ static void load_mapperblock(nes_t *state, SNSS_FILE *snssFile)
    for (i = 0; i < 4; i++)
       mmc_bankrom(8, 0x8000 + (i * 0x2000), snssFile->mapperBlock.prgPages[i]);
 
-   if (state->rominfo->vrom_banks)
-   {
-      for (i = 0; i < 8; i++)
-         mmc_bankvrom(1, i * 0x400, snssFile->mapperBlock.chrPages[i]);
-   }
-   else
-   {
-      ASSERT(state->rominfo->vram);
-
-      for (i = 0; i < 8; i++)
-         ppu_setpage(1, i, state->rominfo->vram);
-   }
+   for (i = 0; i < 8; i++)
+      mmc_bankvrom(1, i * 0x400, snssFile->mapperBlock.chrPages[i]);
 
    if (state->mmc->intf->set_state)
       state->mmc->intf->set_state(&snssFile->mapperBlock);


### PR DESCRIPTION
## Summary
- Split CHR-RAM into 1KB pages on load and apply cartridge mirroring flags via `ppu_mirror`
- Generalize `mmc_bankvrom` to bank switch CHR RAM and ROM with the same API
- Restore CHR mapping during state loads through `mmc_bankvrom`

## Testing
- `gcc -Isrc/nofrendo -c src/nofrendo/nes_mmc.c`
- `gcc -Isrc/nofrendo -c src/nofrendo/nesstate.c`


------
https://chatgpt.com/codex/tasks/task_e_6899faacfa7c8323b9987458080f55a1