### PR TITLE
Rely on timer-driven ticks and avoid busy loop

### DIFF
--- a/src/nofrendo/nes.c
+++ b/src/nofrendo/nes.c
@@ -21,11 +21,20 @@
 ** (adapted to the cycle-accurate PPU, August 2025)
 */
 
+#ifndef _WIN32
+#define _POSIX_C_SOURCE 199309L
+#endif
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <assert.h>
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#include <time.h>
+#endif
 
 #include "noftypes.h"
 #include "nes6502.h"
@@ -422,15 +431,14 @@ void nes_emulate(void)
 
    while (false == nes.poweroff)
    {
-      /* TODO */
-      nofrendo_ticks++;
-      if (nofrendo_ticks != last_ticks)
+      int current_ticks = nofrendo_ticks;
+      if (current_ticks != last_ticks)
       {
-         int tick_diff = nofrendo_ticks - last_ticks;
+         int tick_diff = current_ticks - last_ticks;
 
          frames_to_render += tick_diff;
          /* gui_tick(tick_diff); */
-         last_ticks = nofrendo_ticks;
+         last_ticks = current_ticks;
       }
 
       if (true == nes.pause)
@@ -451,6 +459,17 @@ void nes_emulate(void)
          frames_to_render = 0;
          nes_renderframe(true);
          system_video(true);
+      }
+      else
+      {
+#ifdef _WIN32
+         Sleep(1);
+#else
+         struct timespec ts;
+         ts.tv_sec = 0;
+         ts.tv_nsec = 1000000;
+         nanosleep(&ts, NULL);
+#endif
       }
    }
 }


### PR DESCRIPTION
## Summary
- Remove manual increment of `nofrendo_ticks` and compute frame timing from timer ISR
- Yield CPU with a short sleep when no frames need rendering to avoid busy-waiting
- Add platform-specific includes for sleep support

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `gcc -c src/nofrendo/nes.c -Isrc/nofrendo -std=c99`


------
https://chatgpt.com/codex/tasks/task_e_689a1bc388e88323b59871883d5bea7b