### PR TITLE
Add draw_flag-controlled frame rendering

### DIFF
--- a/src/nofrendo/nes.c
+++ b/src/nofrendo/nes.c
@@ -366,7 +366,11 @@ void nes_poweroff(void)
  * ────────────────────────────────────────────────────────────── */
 void nes_renderframe(bool draw_flag)
 {
-   (void) draw_flag; /* rendering handled inside cycle-accurate PPU */
+   /* Tell the PPU whether the results of this frame should be drawn.  The
+    * PPU still executes all cycles so timing and game state remain accurate,
+    * but it can skip writing pixels to the framebuffer when drawing is
+    * disabled. */
+   ppu_set_draw_enabled(draw_flag);
 
    mapintf_t *mapintf = nes.mmc->intf;
    bool frame_done = false;
@@ -395,7 +399,8 @@ void nes_renderframe(bool draw_flag)
 
 static void system_video(bool draw)
 {
-   /* TODO: hack */
+   /* When draw is false we skip all video work.  The emulator core still
+    * advances a full frame but nothing is pushed to the display. */
    if (false == draw)
       return;
 

--- a/src/nofrendo/nes_ppu.c
+++ b/src/nofrendo/nes_ppu.c
@@ -149,6 +149,11 @@ static bool ppu_four_screen_enabled = false;
 /* Global sprite display toggle */
 static bool sprites_enabled = true;
 
+/* Global flag to control whether the PPU should actually write pixels to the
+ * framebuffer. When disabled the PPU still runs through all cycles so timing
+ * and side effects (sprite-0 hits, scroll updates, etc.) remain intact. */
+static bool draw_enabled = true;
+
 /* PAL timing option */
 static bool ppu_is_pal = false;
 
@@ -719,31 +724,35 @@ void ppu_clock(void)
 
     /* 1. Visible pixel -------------------------------------------------- */
     if (IS_VISIBLE_LINE && ppu.dot >= 1 && ppu.dot <= 256) {
-        uint8_t *fbline = ppu.fb + (ppu.scanline * NES_SCREEN_WIDTH);
+        /* Always resolve sprite/background priority so side effects such as
+         * sprite-0 hits occur even if we skip writing the final pixel. */
         uint8_t bg_pal_row, bg_px;        bg_px  = bg_pixel(&bg_pal_row);
         uint8_t spr_pal_row, spr_pri, spr_px; spr_px = sprite_pixel(&spr_pal_row, &spr_pri);
 
-        uint8_t final_idx;
-        if (!spr_px && !bg_px) {
-            final_idx = pal_read_raw(0);
-        } else if (!spr_px) {
-            final_idx = pal_read_raw((bg_pal_row << 2) | bg_px);
-        } else if (!bg_px) {
-            final_idx = pal_read_raw(0x10 | (spr_pal_row << 2) | spr_px);
-        } else {
-            if (spr_pri) final_idx = pal_read_raw((bg_pal_row << 2) | bg_px);
-            else         final_idx = pal_read_raw(0x10 | (spr_pal_row << 2) | spr_px);
+        if (draw_enabled) {
+            uint8_t *fbline = ppu.fb + (ppu.scanline * NES_SCREEN_WIDTH);
+            uint8_t final_idx;
+            if (!spr_px && !bg_px) {
+                final_idx = pal_read_raw(0);
+            } else if (!spr_px) {
+                final_idx = pal_read_raw((bg_pal_row << 2) | bg_px);
+            } else if (!bg_px) {
+                final_idx = pal_read_raw(0x10 | (spr_pal_row << 2) | spr_px);
+            } else {
+                if (spr_pri) final_idx = pal_read_raw((bg_pal_row << 2) | bg_px);
+                else         final_idx = pal_read_raw(0x10 | (spr_pal_row << 2) | spr_px);
+            }
+
+            /* Apply PPUMASK grayscale and emphasis */
+            if (ppu.mask & 0x01) { /* Grayscale */
+                final_idx = apply_grayscale(final_idx);
+            }
+            if (ppu.mask & 0xE0) { /* Emphasis bits */
+                final_idx = apply_emphasis_idx(final_idx, ppu.mask);
+            }
+
+            fbline[ppu.dot - 1] = final_idx;
         }
-        
-        /* Apply PPUMASK grayscale and emphasis */
-        if (ppu.mask & 0x01) { /* Grayscale */
-            final_idx = apply_grayscale(final_idx);
-        }
-        if (ppu.mask & 0xE0) { /* Emphasis bits */
-            final_idx = apply_emphasis_idx(final_idx, ppu.mask);
-        }
-        
-        fbline[ppu.dot - 1] = final_idx;
     }
 
     /* 2. Shift registers ------------------------------------------------ */
@@ -995,9 +1004,14 @@ void ppu_setdefaultpal(ppu_t *ppu)
     vid_setpalette(nes_palette);
 }
 
-void ppu_displaysprites(bool enable) 
-{ 
+void ppu_displaysprites(bool enable)
+{
     sprites_enabled = enable;
+}
+
+void ppu_set_draw_enabled(bool enable)
+{
+    draw_enabled = enable;
 }
 
 bool ppu_enabled(void)

--- a/src/nofrendo/new_ppu.h
+++ b/src/nofrendo/new_ppu.h
@@ -108,6 +108,7 @@ void   ppu_destroy(ppu_t **ppu);  /* likewise – keeps API intact */
 void   ppu_setpal       (ppu_t *ppu, rgb_t *pal64);
 void   ppu_setdefaultpal(ppu_t *ppu);
 void   ppu_displaysprites(bool enable);
+void   ppu_set_draw_enabled(bool enable); /* skip final pixel writes when false */
 bool   ppu_enabled(void);
 
 /* Debug/GUI functions */

--- a/src/nofrendo/osd.c
+++ b/src/nofrendo/osd.c
@@ -243,8 +243,14 @@ extern bitmap_t *primary_buffer; //, *back_buffer = NULL;
 uint8** nes_emulate_frame(bool draw_flag)
 {
     nes_renderframe(draw_flag);
-    vid_flush();
-    osd_getinput();
+
+    /* Only push the rendered frame to the display and poll input when
+     * drawing is requested.  When draw_flag is false the emulation still
+     * advances internally but no visible frame is produced. */
+    if (draw_flag) {
+        vid_flush();
+        osd_getinput();
+    }
     if (primary_buffer)
         return primary_buffer->line;
     return NULL;


### PR DESCRIPTION
## Summary
- Allow `nes_renderframe` to enable or disable pixel output via a new `ppu_set_draw_enabled` API
- Gate final pixel writes inside the PPU so skipped frames still advance game state without displaying
- Only flush video and poll input when rendering is requested

## Testing
- `gcc -fsyntax-only -Isrc/nofrendo src/nofrendo/nes.c src/nofrendo/nes_ppu.c src/nofrendo/osd.c`
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689a1bc5c7848323b529921c56b9f47b