### PR TITLE
Fix MMC3 IRQ reload and WRAM write gating

### DIFF
--- a/src/nofrendo/nes.h
+++ b/src/nofrendo/nes.h
@@ -115,6 +115,7 @@ extern int nes_insertcart(const char *filename, nes_t *machine);
 extern void nes_setfiq(uint8 state);
 extern void nes_nmi(void);
 extern void nes_irq(void);
+extern void nes_irq_ack(void);
 extern void nes_emulate(void);
 extern void nes_setregion(bool is_pal);
 

--- a/src/nofrendo/wram.c
+++ b/src/nofrendo/wram.c
@@ -16,6 +16,7 @@
  */
 
 #include <stdint.h>
+#include <string.h>
 #include "nes.h"
 #include "nes6502.h"
 #include "wram.h"
@@ -52,11 +53,9 @@ static void remap_page(void)
 /* $6000‑7FFF write gate */
 static void wram_write(uint32_t addr, uint8_t val)
 {
-    if (!wram_en || !base)
-        return;                         
-    if (wram_wp) {
-       printf("WRAM write %04X while WP set, PC=%04X\n",  (unsigned)addr,(unsigned)NES->cpu->pc_reg);   /* or another PC getter */
-    }
+    /* Writes are ignored when window disabled, unmapped or write-protected */
+    if (!wram_en || !base || wram_wp)
+        return;
 
     /* Inlined bank_writebyte() – faster, no extra symbol needed */
     NES->cpu->mem_page[addr >> NES6502_BANKSHIFT]

--- a/src/nofrendo/wram.h
+++ b/src/nofrendo/wram.h
@@ -5,6 +5,7 @@
 #define WRAM_H
 
 #include <stdint.h>     /* for uint32_t / uint8_t */
+#include <stdbool.h>
 
 /* opaque forward-decl: comes from nes.h */
 struct nes_s;
@@ -14,5 +15,8 @@ void wram_init(struct nes_s *nes);
 
 /*  Only mapper 004 (MMC3 / MMC6) needs this call:                    */
 void mmc_bankwram(int size, uint32_t addr, uint8_t bank);
+
+void nes_set_wram_enable(bool enable);
+void nes_set_wram_write_protect(bool protect);
 
 #endif /* WRAM_H */


### PR DESCRIPTION
## Summary
- append 0xFFFFFFFF sentinels to CPU memory handler tables
- treat controller strobe=1 reads as real-time A and ignore WRAM writes when write-protected
- refine MMC3 IRQ/A12 handling and expose IRQ acknowledge prototype

## Testing
- `gcc -std=c99 -Isrc/nofrendo -c src/nofrendo/wram.c`
- `gcc -std=c99 -Isrc/nofrendo -c src/nofrendo/map004.c`
- `gcc -std=c99 -Isrc/nofrendo -c src/nofrendo/nes.c`

------
https://chatgpt.com/codex/tasks/task_e_689a2ae409ac832384f29aa63dc29112