### PR TITLE
Guard against NULL rominfo when resetting NES emulator

### DIFF
--- a/src/nofrendo/nes.c
+++ b/src/nofrendo/nes.c
@@ -509,7 +509,9 @@ void nes_reset(int reset_type)
    if (HARD_RESET == reset_type)
    {
       memset(nes.cpu->mem_page[0], 0, NES_RAMSIZE);
-      if (nes.rominfo->vram)
+      /* rominfo may be NULL when the emulator hasn't loaded a cartridge yet.
+         Guard against dereferencing a NULL pointer before trashing VRAM. */
+      if (nes.rominfo && nes.rominfo->vram)
          mem_trash(nes.rominfo->vram, 0x2000 * nes.rominfo->vram_banks);
    }
 


### PR DESCRIPTION
## Summary
- Avoid dereferencing `nes.rominfo` when the emulator resets before a cartridge is loaded
- Add comment explaining the guard

## Testing
- `gcc -c src/nofrendo/nes.c -Isrc/nofrendo -Isrc -D_POSIX_C_SOURCE=200809L`

------
https://chatgpt.com/codex/tasks/task_e_689b14ba3c94832398f73a74a2dd2658