### PR TITLE
Improve initialization error handling and LEDC configuration

### DIFF
--- a/src/emu_nofrendo.cpp
+++ b/src/emu_nofrendo.cpp
@@ -437,8 +437,20 @@ public:
             return -1;
         }
 
-        nes_emulate_init(path.c_str(),width,height);
+        if (nes_emulate_init(path.c_str(),width,height) != 0) {
+            printf("nes_emulate_init failed for %s\n",path.c_str());
+            unmap_file(_nofrendo_rom);
+            _nofrendo_rom = 0;
+            return -1;
+        }
+
         _lines = nes_emulate_frame(true);   // first frame!
+        if (!_lines) {
+            printf("nes_emulate_frame failed\n");
+            unmap_file(_nofrendo_rom);
+            _nofrendo_rom = 0;
+            return -1;
+        }
         return 0;
     }
 

--- a/src/video_out.h
+++ b/src/video_out.h
@@ -147,7 +147,10 @@ static esp_err_t start_dma(int line_width,int samples_per_cc, int ch = 1)
 void video_init_hw(int line_width, int samples_per_cc)
 {
     // setup apll 4x NTSC or PAL colorburst rate
-    start_dma(line_width,samples_per_cc,1);
+    if (start_dma(line_width,samples_per_cc,1) != ESP_OK) {
+        printf("start_dma failed\n");
+        return;
+    }
 
     // Now ideally we would like to use the decoupled left DAC channel to produce audio
     // But when using the APLL there appears to be some clock domain conflict that causes
@@ -167,7 +170,11 @@ void video_init_hw(int line_width, int samples_per_cc)
     //                   |
     //                   v gnd
 
-    ledcSetup(0,2000000,7);    // 625000 khz is as fast as we go w 7 bits
+    double freq = ledcSetup(0,625000,7);    // 625 kHz is as fast as we go w 7 bits
+    if (freq == 0) {
+        printf("ledcSetup failed\n");
+        return;
+    }
     ledcAttachPin(AUDIO_PIN, 0);
     ledcWrite(0,0);
 


### PR DESCRIPTION
## Summary
- guard NES cartridge insertion with init and frame failure checks
- validate DMA/LEDC setup and use safe 625 kHz default

## Testing
- `g++ -std=c++17 -Isrc -Isrc/nofrendo -c -fsyntax-only src/emu_nofrendo.cpp 2>&1 | head -n 20` *(fails: `uint8_t` does not name a type)*

------
https://chatgpt.com/codex/tasks/task_e_689b2dfceaa8832383cdfc6be823b2a6