### PR TITLE
Improve initialization error handling and LEDC configuration

### DIFF
--- a/src/emu.h
+++ b/src/emu.h
@@ -24,6 +24,8 @@
 #include "string.h"
 #include "dirent.h"
 
+#include <stdint.h>
+
 #include <string>
 #include <vector>
 #include <map>

--- a/src/emu_nofrendo.cpp
+++ b/src/emu_nofrendo.cpp
@@ -437,8 +437,20 @@ public:
             return -1;
         }
 
-        nes_emulate_init(path.c_str(),width,height);
+        if (nes_emulate_init(path.c_str(),width,height) != 0) {
+            printf("nes_emulate_init failed for %s\n",path.c_str());
+            unmap_file(_nofrendo_rom);
+            _nofrendo_rom = 0;
+            return -1;
+        }
+
         _lines = nes_emulate_frame(true);   // first frame!
+        if (!_lines) {
+            printf("nes_emulate_frame failed\n");
+            unmap_file(_nofrendo_rom);
+            _nofrendo_rom = 0;
+            return -1;
+        }
         return 0;
     }
 

--- a/src/nofrendo/osd.c
+++ b/src/nofrendo/osd.c
@@ -263,10 +263,13 @@ int nes_emulate_init(const char* path, int width, int height)
            return -1;
         if (vid_init(width,height,&sdlDriver))
             return -1;
+        if (vid_setmode(NES_SCREEN_WIDTH, 240))
+            return -1;
         event_init();
         event_set_system(system_nes);
         _nes_p = nes_create();
-        vid_setmode(NES_SCREEN_WIDTH, 240);
+        if (!_nes_p)
+            return -1;
     }
     if (nes_insertcart(path,_nes_p))
         return -1;

--- a/src/nofrendo/vid_drv.c
+++ b/src/nofrendo/vid_drv.c
@@ -132,13 +132,15 @@ void vid_setpalette(rgb_t *p)
 }
 
 /* blits a bitmap onto primary buffer */
-void vid_blit(bitmap_t *bitmap, int src_x, int src_y, int dest_x, int dest_y, 
+void vid_blit(bitmap_t *bitmap, int src_x, int src_y, int dest_x, int dest_y,
               int width, int height)
 {
    int bitmap_pitch, primary_pitch;
    uint8 *dest_ptr, *src_ptr;
 
    ASSERT(bitmap);
+   if (!primary_buffer)
+      return;
 
    /* clip to source */
    if (src_y >= bitmap->height)
@@ -337,8 +339,8 @@ void vid_flush(void)
    bitmap_t *temp;
    int num_dirties;
    rect_t dirty_rects[MAX_DIRTIES];
-
-   ASSERT(driver);
+   if (!driver || !primary_buffer)
+      return;
 
    if (true == driver->invalidate)
    {

--- a/src/video_out.h
+++ b/src/video_out.h
@@ -147,7 +147,10 @@ static esp_err_t start_dma(int line_width,int samples_per_cc, int ch = 1)
 void video_init_hw(int line_width, int samples_per_cc)
 {
     // setup apll 4x NTSC or PAL colorburst rate
-    start_dma(line_width,samples_per_cc,1);
+    if (start_dma(line_width,samples_per_cc,1) != ESP_OK) {
+        printf("start_dma failed\n");
+        return;
+    }
 
     // Now ideally we would like to use the decoupled left DAC channel to produce audio
     // But when using the APLL there appears to be some clock domain conflict that causes
@@ -167,7 +170,11 @@ void video_init_hw(int line_width, int samples_per_cc)
     //                   |
     //                   v gnd
 
-    ledcSetup(0,2000000,7);    // 625000 khz is as fast as we go w 7 bits
+    double freq = ledcSetup(0,625000,7);    // 625 kHz is as fast as we go w 7 bits
+    if (freq == 0) {
+        printf("ledcSetup failed\n");
+        return;
+    }
     ledcAttachPin(AUDIO_PIN, 0);
     ledcWrite(0,0);
 


### PR DESCRIPTION
## Summary
- Allocate NES video buffer before creating the machine to avoid null frame buffer during reset
- Guard blit and flush routines against missing video buffers
- Include `<stdint.h>` for fixed-width type definitions

## Testing
- `g++ -std=c++17 -Isrc -Isrc/nofrendo -c -fsyntax-only src/emu_nofrendo.cpp` *(passes: no output)*
- `gcc -std=c99 -Isrc -Isrc/nofrendo -c -fsyntax-only src/nofrendo/vid_drv.c` *(warnings: pointer-to-int-cast)*
- `gcc -std=c99 -Isrc -Isrc/nofrendo -c -fsyntax-only src/nofrendo/osd.c` *(fails: storage size of 'sa' isn't known)*

------
https://chatgpt.com/codex/tasks/task_e_689b2dfceaa8832383cdfc6be823b2a6