### PR TITLE
Fix heap corruption from incorrect delete

### DIFF
--- a/src/emu.cpp
+++ b/src/emu.cpp
@@ -104,7 +104,7 @@ public:
 
     ~CrapFS()
     {
-        delete _buf;
+        delete[] _buf;
     }
 
     uint32_t align(uint32_t n)
@@ -163,7 +163,7 @@ public:
             i += n;
         }
         fclose(f);
-        delete buf;
+        delete[] buf;
         return err;
     }
 
@@ -234,7 +234,7 @@ uint8_t* map_file(const char* path, int len)
 
 void unmap_file(uint8_t* ptr)
 {
-    delete ptr;
+    delete[] ptr;
 }
 
 FILE* mkfile(const char* path)

--- a/src/emu_atari800.cpp
+++ b/src/emu_atari800.cpp
@@ -1235,7 +1235,7 @@ public:
             uint8_t* data;
             if (load(path+".cfg",&data,&len) == 0) {
                 string cfg((const char*)data,len);
-                delete data;
+                delete[] data;
                 return cfg + " \"" + path + "\"";
             }
         }


### PR DESCRIPTION
## Summary
- Free `CrapFS` buffers with `delete[]` instead of `delete` to avoid heap corruption
- Correct array deallocation in Atari config loading and file unmapping

## Testing
- `g++ -std=c++11 -fsyntax-only src/emu.cpp` *(fails: ../miniz.h: No such file or directory)*
- `g++ -std=c++11 -fsyntax-only src/emu_atari800.cpp`


------
https://chatgpt.com/codex/tasks/task_e_689b5a007da48323906f3b2d1b4d8595