### PR TITLE
Use eval read latch for OAMDATA reads during sprite eval

### DIFF
--- a/src/nofrendo/nes_ppu.c
+++ b/src/nofrendo/nes_ppu.c
@@ -947,7 +947,12 @@ uint8_t ppu_read(uint32_t addr)
         ppu.open_bus = ret;
         break;
     case 4: /* OAMDATA */
-        ret = ppu.oam[ppu.oam_addr];
+        if (RENDERING_ENABLED && (IS_VISIBLE_LINE || IS_PRERENDER_LINE) &&
+            ppu.dot >= 65 && ppu.dot <= 256) {
+            ret = ppu.eval_read_latch;
+        } else {
+            ret = ppu.oam[ppu.oam_addr];
+        }
         ppu.open_bus = ret;
         break;
     case 7: /* PPUDATA */


### PR DESCRIPTION
## Summary
- Return the internal sprite evaluation read latch when reading $2004 during the sprite evaluation window
- Preserve existing OAMDATA behavior outside evaluation

## Testing
- `gcc -c src/nofrendo/nes_ppu.c -Isrc/nofrendo`

------
https://chatgpt.com/codex/tasks/task_e_689fa7b9f9c88323a0a5920f64174d08