### PR TITLE
Add cooperative yields to keep core 0 watchdog satisfied

### DIFF
--- a/esp_8_bit.ino
+++ b/esp_8_bit.ino
@@ -95,8 +95,11 @@ void emu_task(void* arg)
     printf("emu_task %s running on core %d at %dmhz\n",
       _emu->name.c_str(),xPortGetCoreID(),rtc_clk_cpu_freq_value(rtc_clk_cpu_freq_get()));
     emu_init();
-    for (;;)
+    for (;;) {
       emu_loop();
+      // Give IDLE0 a chance to run so the task watchdog is satisfied
+      vTaskDelay(1);
+    }
 }
 
 esp_err_t mount_filesystem()

--- a/src/emu_nofrendo.cpp
+++ b/src/emu_nofrendo.cpp
@@ -23,6 +23,8 @@ extern "C" {
 #include "nofrendo/event.h"
 };
 #include "math.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 using namespace std;
 
@@ -472,8 +474,12 @@ public:
         if (nes_sound_cb) {
             nes_sound_cb(b,n);  // 8 bit unsigned
             uint8_t* b8 = (uint8_t*)b;
-            for (int i = n-1; i >= 0; i--)
+            for (int i = n-1; i >= 0; i--) {
                 b[i] = (b8[i] ^ 0x80) << 8;  // turn it back into signed 16
+                // Occasionally yield to allow lower priority tasks and the idle task to run
+                if ((i & 2047) == 0)
+                    vTaskDelay(0);
+            }
         }
         else
             memset(b,0,2*n);


### PR DESCRIPTION
## Summary
- give IDLE0 time each frame by delaying in `emu_task`
- occasionally yield during audio mixing to avoid starving other tasks

## Testing
- `g++ -x c++ -std=gnu++11 -fsyntax-only esp_8_bit.ino` *(fails: esp_system.h: No such file or directory)*
- `g++ -x c++ -std=gnu++11 -fsyntax-only src/emu_nofrendo.cpp` *(fails: freertos/FreeRTOS.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b2b7a95883238324f0fe2900f420