### PR TITLE
Ensure cross-core visibility for video buffer

### DIFF
--- a/esp_8_bit.ino
+++ b/esp_8_bit.ino
@@ -85,6 +85,7 @@ void emu_loop()
     gui_update();
     _frame_time = xthal_get_ccount() - t;
     _lines = _emu->video_buffer();
+    __sync_synchronize();
     _drawn++;
     taskYIELD();
 }
@@ -170,6 +171,7 @@ void loop()
   #else
   // start the video after emu has started
   if (!_inited) {
+    __sync_synchronize();
     if (_lines) {
       printf("video_init\n");
       video_init(_emu->cc_width,_emu->flavor,_emu->composite_palette(),_emu->standard); // start the A/V pump

--- a/src/video_out.h
+++ b/src/video_out.h
@@ -303,7 +303,7 @@ uint32_t us() {
 #define P2 (color)
 #define P3 (color << 8)
 
-uint8_t** _lines; // filled in by emulator
+volatile uint8_t** _lines; // filled in by emulator
 volatile int _line_counter = 0;
 volatile int _frame_counter = 0;
 
@@ -775,6 +775,7 @@ void IRAM_ATTR test_wave(volatile void* vbuf, int t = 1)
 #ifdef ESP_PLATFORM
 void video_sync()
 {
+  __sync_synchronize();
   if (!_lines)
     return;
   int n = 0;
@@ -793,6 +794,7 @@ void video_sync()
 extern "C"
 void IRAM_ATTR video_isr(volatile void* vbuf)
 {
+    __sync_synchronize();
     if (!_lines)
         return;
 


### PR DESCRIPTION
## Summary
- Mark `_lines` as a volatile pointer so the video buffer is always reloaded from memory
- Add `__sync_synchronize()` barriers after writes and before reads in `emu_loop`, `loop`, and ISR helpers

## Testing
- `g++ -std=c++17 -x c++ -c esp_8_bit.ino` *(fails: esp_system.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a639b62a7c8323b0e461541ed669c4