### PR TITLE
Reset line pointer after video buffer cleanup

### DIFF
--- a/src/nofrendo/vid_drv.c
+++ b/src/nofrendo/vid_drv.c
@@ -30,6 +30,9 @@
 #include "vid_drv.h"
 #include "gui.h"
 #include "osd.h"
+#include <stdint.h>
+
+extern uint8_t **_lines;
 
 /* hardware surface */
 static bitmap_t *screen = NULL;
@@ -368,7 +371,10 @@ void vid_flush(void)
 int vid_setmode(int width, int height)
 {
    if (NULL != primary_buffer)
+   {
       bmp_destroy(&primary_buffer);
+      _lines = NULL;
+   }
 //   if (NULL != back_buffer)
 //      bmp_destroy(&back_buffer);
 
@@ -382,6 +388,7 @@ int vid_setmode(int width, int height)
    if (NULL == back_buffer)
    {
       bmp_destroy(&primary_buffer);
+      _lines = NULL;
       return -1;
    }
    bmp_clear(back_buffer, GUI_BLACK);
@@ -441,7 +448,10 @@ void vid_shutdown(void)
       return;
 
    if (NULL != primary_buffer)
+   {
       bmp_destroy(&primary_buffer);
+      _lines = NULL;
+   }
 #if 0
    if (NULL != back_buffer)
       bmp_destroy(&back_buffer);


### PR DESCRIPTION
## Summary
- clear global `_lines` whenever the video `primary_buffer` is destroyed to avoid ISR use-after-free
- keep `_lines` nullified on shutdown

## Testing
- `gcc -c src/nofrendo/vid_drv.c -I src/nofrendo -I src -o /tmp/vid_drv.o`

------
https://chatgpt.com/codex/tasks/task_e_68ac7b9cdc24832385751a0c1d155f30