### PR TITLE
Fix volatile line buffer type for video blit

### DIFF
--- a/src/emu_nofrendo.cpp
+++ b/src/emu_nofrendo.cpp
@@ -208,7 +208,7 @@ void osd_setsound(void (*playfunc)(void *buffer, int length))
 }
 
 std::string to_string(int i);
-extern uint8_t** _lines; // global video line pointers provided by PPU
+extern uint8_t** volatile _lines; // global video line pointers provided by PPU
 
 class EmuNofrendo : public Emu {
     uint8_t** lines_;

--- a/src/nofrendo/nes_ppu.c
+++ b/src/nofrendo/nes_ppu.c
@@ -20,7 +20,7 @@
 #include "log.h"
 
 /* Video output globals populated during PPU reset */
-extern uint8_t **_lines;
+extern uint8_t** volatile _lines;
 extern int _active_lines;
 
 /* ─────────────────── Fast-code / inline helpers ─────────────────── */

--- a/src/nofrendo/vid_drv.c
+++ b/src/nofrendo/vid_drv.c
@@ -32,7 +32,7 @@
 #include "osd.h"
 #include <stdint.h>
 
-extern uint8_t **_lines;
+extern uint8_t** volatile _lines;
 
 /* hardware surface */
 static bitmap_t *screen = NULL;

--- a/src/video_out.h
+++ b/src/video_out.h
@@ -303,7 +303,7 @@ uint32_t us() {
 #define P2 (color)
 #define P3 (color << 8)
 
-volatile uint8_t** _lines; // filled in by emulator
+uint8_t** volatile _lines; // filled in by emulator
 volatile int _line_counter = 0;
 volatile int _frame_counter = 0;
 


### PR DESCRIPTION
## Summary
- define the global line buffer pointer as a volatile pointer to uint8_t* to match access patterns
- update all extern declarations to use the new volatile pointer type

## Testing
- `gcc -std=c99 -I src -I src/nofrendo -fsyntax-only src/nofrendo/nes_ppu.c`
- `gcc -std=c99 -I src -I src/nofrendo -fsyntax-only src/nofrendo/vid_drv.c`
- `g++ -std=c++11 -I src -I src/nofrendo -fsyntax-only src/emu_nofrendo.cpp` *(fails: freertos/FreeRTOS.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7f272c28832387d96ba21bfd30aa